### PR TITLE
Tiny fixes

### DIFF
--- a/opustags.c
+++ b/opustags.c
@@ -7,6 +7,12 @@
 #include <unistd.h>
 #include <ogg/ogg.h>
 
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#endif
+
 typedef struct {
     uint32_t vendor_length;
     const char *vendor_string;

--- a/opustags.c
+++ b/opustags.c
@@ -56,8 +56,10 @@ int parse_tags(char *data, long len, opus_tags *tags){
         if(pos > len)
             return -1;
     }
-    if(pos != len)
-        return -1;
+
+    if(pos < len)
+        fprintf(stderr, "warning: %ld unused bytes at the end of the OpusTags packet\n", len - pos);
+
     return 0;
 }
 


### PR DESCRIPTION
* adds the required `#define`s for macOS compatibility
* warns instead of crashing when an `OpusTags` packet has padding