### PR TITLE
macOS compatibility (sort of)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+/*.sh
+/build
+Dockerfile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(BEFORE src "${CMAKE_BINARY_DIR}")
 
 add_library(
 	libopustags
-	OBJECT
+	STATIC
 	src/cli.cc
 	src/ogg.cc
 	src/opus.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(OGG REQUIRED ogg)
 add_compile_options(${OGG_CFLAGS})
+link_directories(${OGG_LIBRARY_DIRS})
 
 configure_file(src/config.h.in config.h @ONLY)
-include_directories(BEFORE src "${CMAKE_BINARY_DIR}")
+include_directories(BEFORE src "${CMAKE_BINARY_DIR}" ${OGG_INCLUDE_DIRS})
 
 add_library(
 	libopustags
@@ -25,6 +26,10 @@ add_library(
 	src/system.cc
 )
 target_link_libraries(libopustags PUBLIC ${OGG_LIBRARIES})
+
+if (APPLE)
+	target_link_libraries(libopustags PUBLIC iconv)
+endif()
 
 add_executable(opustags src/opustags.cc)
 target_link_libraries(opustags libopustags)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# This dockerfile can be used to both build a containerized version of the application
+# and to self-test its build.
+# * To self-test, simply `docker build -t opustags .`; `make check` is run as the final step anyway.
+# * To use the dockerized version, `docker run -it opustags opustags -h` (etc.)
+
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y make cmake g++ libogg-dev pkg-config ffmpeg liblist-moreutils-perl locales
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+ADD . /src
+WORKDIR /build
+RUN env CXX=g++ cmake /src && make && make install
+# We need to run tests as a regular user, since on Docker /dev is a writable directory
+# for root (it's backed by a tmpfs).  This would make the "device as partial file" test fail.
+RUN useradd ubuntu
+RUN mkdir -p /build && chown -R ubuntu:ubuntu /build /src
+USER ubuntu
+RUN env CXX=g++ make check

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -12,6 +12,7 @@
 #include <config.h>
 #include <opustags.h>
 
+#include <errno.h>
 #include <getopt.h>
 #include <limits.h>
 #include <string.h>

--- a/src/ogg.cc
+++ b/src/ogg.cc
@@ -10,6 +10,7 @@
 
 #include <opustags.h>
 
+#include <errno.h>
 #include <string.h>
 
 using namespace std::literals::string_literals;

--- a/src/system.cc
+++ b/src/system.cc
@@ -11,7 +11,9 @@
 
 #include <opustags.h>
 
+#include <errno.h>
 #include <string.h>
+#include <unistd.h>
 
 ot::status ot::partial_file::open(const char* destination)
 {


### PR DESCRIPTION
As discussed over email, here's a PR that makes the current `opustags` _build_ on macOS Mojave. However, `make check` does not finish successfully – more about that in a second.

To ensure I had a sane baseline to go on, I added a little Ubuntu 18.04 Dockerfile that makes it easier to build the project in a contained (pun intended) Linux environment. However the cmake there (3.10.2) complained about the attempt to link things to the OBJECT library `libopustags`, so I changed that to STATIC instead. (I've never really touched cmake, so I can only hope that's somewhere near correct – at the very least, the output filename is a little silly: `Linking CXX static library liblibopustags.a`...)  
However `make check` doesn't run successfully within the container; see https://gist.github.com/akx/987b719d0329da9a3140f90c649fa1f2 for the output.

On macOS, one needs a couple additional headers to have `errno` and `mkstemps` available; those were a breeze to add. Additionally, since `libogg` isn't a system library on macOS and people tend to install it from Homebrew, the library directory needs to be added to the link path; also, `iconv` is not available in the default linkage, so it needs to be added too.

Again, unfortunately, `make check` doesn't run successfully: https://gist.github.com/akx/ce7c0763a6c489fb7749039b9a18909a