### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 opustags changelog
 ==================
 
+1.5.0 - 2020-11-08
+------------------
+
+- Introduce --edit for interactive edition.
+
 1.4.0 - 2020-10-04
 ------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 
 project(
 	opustags
-	VERSION 1.4.0
+	VERSION 1.5.0
 	LANGUAGES CXX
 )
 


### PR DESCRIPTION
--edit is quite a big feature, and there is still a pending fix for BSD (#33). Now sounds like a good time to release 1.5.0.

@omar-polo --edit spawns a subprocess, which is something that tends to differ across platforms. I think opustags is still POSIX-compatible, but I’d feel more confident if someone tested it. If you have the time to do that, I’d be grateful! Feel free to give your feedback on the feature too.