### PR TITLE
Add flexibility regarding encodings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,6 @@ More generally, here are a few features that could be added in the future:
 - Logicial stream listing and selection for multiplexed files.
 - Escaping control characters with --escape.
 - Dump binary packets with --binary.
-- Skip encoding conversion with --raw.
 - Edition of the vendor string.
 - Edition of the arbitrary binary block past the comments.
 - Support for OpusTags packets spanning multiple pages (> 64 kB).

--- a/README.md
+++ b/README.md
@@ -62,5 +62,6 @@ Documentation
       -s, --set FIELD=VALUE         replace a comment
       -S, --set-all                 import comments from standard input
       -e, --edit                    edit tags interactively in VISUAL/EDITOR
+      --raw                         disable encoding conversion
 
 See the man page, `opustags.1`, for extensive documentation.

--- a/opustags.1
+++ b/opustags.1
@@ -103,6 +103,13 @@ Blank lines and lines starting with \fI#\fP are ignored.
 Edit tags interactively by spawning the program specified by the EDITOR
 environment variable. The allowed format is the same as \fB--set-all\fP.
 If TERM and VISUAL are set, VISUAL takes precedence over EDITOR.
+.TP
+.B \-\-raw
+OpusTags metadata should always be encoded in UTF-8, as per RFC 7845. However, some files may be
+corrupted or possibly even contain intentional binary data. In that case, --raw lets you edit that
+kind of binary data without ensuring the validity of the tags encoding. This option may also be
+useful when your system encoding is different from UTF-8 and you wish to preserve the full UTF-8
+character set even though your system cannot display it.
 .SH EXAMPLES
 .PP
 List all the tags in file foo.opus:

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -183,9 +183,8 @@ ot::status ot::parse_options(int argc, char** argv, ot::options& opt, FILE* comm
  */
 void ot::print_comments(const std::list<std::string>& comments, FILE* output, bool raw)
 {
-	static ot::encoding_converter from_utf8("UTF-8", "//IGNORE");
+	static ot::encoding_converter from_utf8("UTF-8", "");
 	std::string local;
-	bool info_lost = false;
 	bool bad_comments = false;
 	bool has_newline = false;
 	bool has_control = false;
@@ -197,9 +196,7 @@ void ot::print_comments(const std::list<std::string>& comments, FILE* output, bo
 		} else {
 			ot::status rc = from_utf8(utf8_comment, local);
 			comment = &local;
-			if (rc == ot::st::information_lost) {
-				info_lost = true;
-			} else if (rc != ot::st::ok) {
+			if (rc != ot::st::ok) {
 				bad_comments = true;
 				continue;
 			}
@@ -214,10 +211,8 @@ void ot::print_comments(const std::list<std::string>& comments, FILE* output, bo
 		fwrite(comment->data(), 1, comment->size(), output);
 		putc('\n', output);
 	}
-	if (info_lost)
-		fputs("warning: Some characters could not be converted to your system encoding and have been discarded. See --raw.\n", stderr);
 	if (bad_comments)
-		fputs("warning: Some tags are not properly encoded and have not been displayed.\n", stderr);
+		fputs("warning: Some tags could not be displayed because of incompatible encoding. See --raw.\n", stderr);
 	if (has_newline)
 		fputs("warning: Some tags contain newline characters. "
 		      "These are not supported by --set-all.\n", stderr);

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -171,7 +171,7 @@ ot::status ot::parse_options(int argc, char** argv, ot::options& opt, FILE* comm
  */
 void ot::print_comments(const std::list<std::string>& comments, FILE* output)
 {
-	static ot::encoding_converter from_utf8("UTF-8", "//TRANSLIT");
+	static ot::encoding_converter from_utf8("UTF-8", "//IGNORE");
 	std::string local;
 	bool info_lost = false;
 	bool bad_comments = false;
@@ -195,7 +195,7 @@ void ot::print_comments(const std::list<std::string>& comments, FILE* output)
 		putc('\n', output);
 	}
 	if (info_lost)
-		fputs("warning: Some tags have been transliterated to your system encoding.\n", stderr);
+		fputs("warning: Some characters are not supported by your system encoding and have been discarded.\n", stderr);
 	if (bad_comments)
 		fputs("warning: Some tags are not properly encoded and have not been displayed.\n", stderr);
 	if (has_newline)

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -86,14 +86,14 @@ ot::status ot::parse_options(int argc, char** argv, ot::options& opt, FILE* comm
 			opt.overwrite = true;
 			break;
 		case 'd':
-			rc = to_utf8(optarg, strlen(optarg), utf8);
+			rc = to_utf8(optarg, utf8);
 			if (rc != ot::st::ok)
 				return {st::bad_arguments, "Could not encode argument into UTF-8: " + rc.message};
 			opt.to_delete.emplace_back(std::move(utf8));
 			break;
 		case 'a':
 		case 's':
-			rc = to_utf8(optarg, strlen(optarg), utf8);
+			rc = to_utf8(optarg, utf8);
 			if (rc != ot::st::ok)
 				return {st::bad_arguments, "Could not encode argument into UTF-8: " + rc.message};
 			if ((equal = utf8.find('=')) == std::string::npos)
@@ -225,7 +225,7 @@ ot::status ot::read_comments(FILE* input, std::list<std::string>& comments)
 			return rc;
 		}
 		std::string utf8;
-		ot::status rc = to_utf8(line, nread, utf8);
+		ot::status rc = to_utf8(std::string_view(line, nread), utf8);
 		if (rc == ot::st::ok) {
 			comments.emplace_back(std::move(utf8));
 		} else {

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -161,9 +161,7 @@ public:
 	 * abort the processing. If some character could not be converted perfectly, keep converting
 	 * the string and finally return #st::information_lost.
 	 */
-	status operator()(const std::string& in, std::string& out)
-		{ return (*this)(in.data(), in.size(), out); }
-	status operator()(const char* in, size_t n, std::string& out);
+	status operator()(std::string_view in, std::string& out);
 private:
 	iconv_t cd; /**< conversion descriptor */
 };

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -65,7 +65,6 @@ enum class st {
 	cancel,
 	/* System */
 	badly_encoded,
-	information_lost,
 	child_process_failed,
 	/* Ogg */
 	bad_stream,
@@ -158,8 +157,7 @@ public:
 	~encoding_converter();
 	/**
 	 * Convert text using iconv. If the input sequence is invalid, return #st::badly_encoded and
-	 * abort the processing. If some character could not be converted perfectly, keep converting
-	 * the string and finally return #st::information_lost.
+	 * abort the processing, leaving out in an undefined state.
 	 */
 	status operator()(std::string_view in, std::string& out);
 private:

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -450,7 +450,7 @@ struct options {
 	 *
 	 * Option: --delete, --set
 	 */
-	std::vector<std::string> to_delete;
+	std::list<std::string> to_delete;
 	/**
 	 * Delete all the existing comments.
 	 *

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -466,6 +466,12 @@ struct options {
 	 * Options: --add, --set, --set-all
 	 */
 	std::list<std::string> to_add;
+	/**
+	 * Disable encoding conversions. OpusTags are specified to always be encoded as UTF-8, but
+	 * if for some reason a specific file contains binary tags that someone would like to
+	 * extract and set as-is, encoding conversion would get in the way.
+	 */
+	bool raw = false;
 };
 
 /**
@@ -484,14 +490,14 @@ status parse_options(int argc, char** argv, options& opt, FILE* comments);
  *
  * The output generated is meant to be parseable by #ot::read_comments.
  */
-void print_comments(const std::list<std::string>& comments, FILE* output);
+void print_comments(const std::list<std::string>& comments, FILE* output, bool raw);
 
 /**
  * Parse the comments outputted by #ot::print_comments.
  *
  * The comments are converted from the system encoding to UTF-8, and returned as UTF-8.
  */
-status read_comments(FILE* input, std::list<std::string>& comments);
+status read_comments(FILE* input, std::list<std::string>& comments, bool raw);
 
 /**
  * Remove all comments matching the specified selector, which may either be a field name or a

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -488,7 +488,7 @@ status parse_options(int argc, char** argv, options& opt, FILE* comments);
  *
  * The output generated is meant to be parseable by #ot::read_comments.
  */
-void print_comments(const std::list<std::string>& comments, FILE* output, bool raw);
+status print_comments(const std::list<std::string>& comments, FILE* output, bool raw);
 
 /**
  * Parse the comments outputted by #ot::print_comments.

--- a/src/system.cc
+++ b/src/system.cc
@@ -104,13 +104,13 @@ ot::encoding_converter::~encoding_converter()
 	iconv_close(cd);
 }
 
-ot::status ot::encoding_converter::operator()(const char* in, size_t n, std::string& out)
+ot::status ot::encoding_converter::operator()(std::string_view in, std::string& out)
 {
 	iconv(cd, nullptr, nullptr, nullptr, nullptr);
 	out.clear();
-	out.reserve(n);
-	char* in_cursor = const_cast<char*>(in);
-	size_t in_left = n;
+	out.reserve(in.size());
+	char* in_cursor = const_cast<char*>(in.data());
+	size_t in_left = in.size();
 	constexpr size_t chunk_size = 1024;
 	char chunk[chunk_size];
 	bool lost_information = false;
@@ -130,7 +130,7 @@ ot::status ot::encoding_converter::operator()(const char* in, size_t n, std::str
 			break;
 		} else if (rc == (size_t) -1 && errno != E2BIG) {
 			return {ot::st::badly_encoded,
-			        "Could not convert string '" + std::string(in, n) + "': " +
+			        "Could not convert string '" + std::string(in) + "': " +
 			        strerror(errno)};
 		} else if (rc != 0 && rc != (size_t) -1) {
 			lost_information = true;

--- a/src/system.cc
+++ b/src/system.cc
@@ -118,13 +118,24 @@ ot::status ot::encoding_converter::operator()(const char* in, size_t n, std::str
 		char *out_cursor = chunk;
 		size_t out_left = chunk_size;
 		size_t rc = iconv(cd, &in_cursor, &in_left, &out_cursor, &out_left);
-		if (rc == (size_t) -1 && errno != E2BIG)
+		out.append(chunk, out_cursor - chunk);
+
+		// With //IGNORE, iconv yields EILSEQ on bad conversion but still returns reasonable
+		// data. Note than EILSEQ is returned at the very end so it’s basically like a fatal
+		// error on the last chunk. When the output buffer is too small, it yields E2BIG and
+		// we need to loop. Any other error is fatal. A return code other than 0 or -1
+		// indicates a lossy transliteration.
+		if (rc == (size_t) -1 && errno == EILSEQ) {
+			lost_information = true;
+			break;
+		} else if (rc == (size_t) -1 && errno != E2BIG) {
 			return {ot::st::badly_encoded,
 			        "Could not convert string '" + std::string(in, n) + "': " +
 			        strerror(errno)};
-		if (rc != 0)
+		} else if (rc != 0 && rc != (size_t) -1) {
 			lost_information = true;
-		out.append(chunk, out_cursor - chunk);
+		}
+
 		if (in_cursor == nullptr)
 			break;
 		else if (in_left == 0)
@@ -132,8 +143,7 @@ ot::status ot::encoding_converter::operator()(const char* in, size_t n, std::str
 	}
 	if (lost_information)
 		return {ot::st::information_lost,
-		        "Some characters could not be converted into the target encoding "
-		        "in string '" + std::string(in, n) + "'."};
+		        "Some characters could not be converted into the target encoding."};
 	return ot::st::ok;
 }
 

--- a/src/system.cc
+++ b/src/system.cc
@@ -121,7 +121,7 @@ ot::status ot::encoding_converter::operator()(std::string_view in, std::string& 
 		if (rc == (size_t) -1 && errno == E2BIG) {
 			// Loop normally.
 		} else if (rc == (size_t) -1) {
-			return {ot::st::badly_encoded, strerror(errno)};
+			return {ot::st::badly_encoded, strerror(errno) + "."s};
 		} else if (rc != 0) {
 			return {ot::st::badly_encoded,
 				"Some characters could not be converted into the target encoding."};

--- a/t/cli.cc
+++ b/t/cli.cc
@@ -71,7 +71,7 @@ void check_good_arguments()
 	opt = parse({"opustags", "x", "--output", "y", "-D", "-s", "X=Y Z", "-d", "a=b"});
 	if (opt.paths_in.size() != 1 || opt.paths_in.front() != "x" || !opt.path_out ||
 	    opt.path_out != "y" || !opt.delete_all || opt.overwrite || opt.to_delete.size() != 2 ||
-	    opt.to_delete[0] != "X" || opt.to_delete[1] != "a=b" ||
+	    opt.to_delete.front() != "X" || *std::next(opt.to_delete.begin()) != "a=b" ||
 	    opt.to_add != std::list<std::string>{"X=Y Z"})
 		throw failure("unexpected option parsing result for case #1");
 

--- a/t/cli.cc
+++ b/t/cli.cc
@@ -153,13 +153,13 @@ void check_bad_arguments()
 	error_case({"opustags", "--edit", "x", "-i", "-D"}, "Cannot mix --edit with -adDsS.", "mixing -e and -D");
 	error_case({"opustags", "--edit", "x", "-i", "-S"}, "Cannot mix --edit with -adDsS.", "mixing -e and -S");
 	error_case({"opustags", "-d", "\xFF", "x"},
-	           "Could not encode argument into UTF-8: Some characters could not be converted into the target encoding.",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
 	           "-d with binary data");
 	error_case({"opustags", "-a", "X=\xFF", "x"},
-	           "Could not encode argument into UTF-8: Some characters could not be converted into the target encoding.",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
 	           "-a with binary data");
 	error_case({"opustags", "-s", "X=\xFF", "x"},
-	           "Could not encode argument into UTF-8: Some characters could not be converted into the target encoding.",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
 	           "-s with binary data");
 }
 

--- a/t/cli.cc
+++ b/t/cli.cc
@@ -153,13 +153,13 @@ void check_bad_arguments()
 	error_case({"opustags", "--edit", "x", "-i", "-D"}, "Cannot mix --edit with -adDsS.", "mixing -e and -D");
 	error_case({"opustags", "--edit", "x", "-i", "-S"}, "Cannot mix --edit with -adDsS.", "mixing -e and -S");
 	error_case({"opustags", "-d", "\xFF", "x"},
-	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character.",
 	           "-d with binary data");
 	error_case({"opustags", "-a", "X=\xFF", "x"},
-	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character.",
 	           "-a with binary data");
 	error_case({"opustags", "-s", "X=\xFF", "x"},
-	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character",
+	           "Could not encode argument into UTF-8: Invalid or incomplete multibyte or wide character.",
 	           "-s with binary data");
 }
 

--- a/t/opustags.t
+++ b/t/opustags.t
@@ -275,11 +275,11 @@ is_deeply(opustags('-i', 'out.opus', "--add=I=\xf9\xce", {mode => ':raw'}), ['',
 
 is_deeply(opustags('out.opus', {mode => ':raw'}), [<<"END_OUT", <<'END_ERR', 0], 'read tags in ISO-8859-1');
 encoder=Lavc58.18.100 libopus
-TITLE=???
+TITLE=
 ARTIST=\xe9\xe0\xe7
 I=\xf9\xce
 END_OUT
-warning: Some tags have been transliterated to your system encoding.
+warning: Some characters are not supported by your system encoding and have been discarded.
 END_ERR
 
 $ENV{LC_ALL} = '';

--- a/t/opustags.t
+++ b/t/opustags.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 47;
+use Test::More tests => 50;
 
 use Digest::MD5;
 use File::Basename;
@@ -72,6 +72,7 @@ Options:
   -s, --set FIELD=VALUE         replace a comment
   -S, --set-all                 import comments from standard input
   -e, --edit                    edit tags interactively in VISUAL/EDITOR
+  --raw                         disable encoding conversion
 
 See the man page for extensive documentation.
 EOF
@@ -279,7 +280,7 @@ TITLE=
 ARTIST=\xe9\xe0\xe7
 I=\xf9\xce
 END_OUT
-warning: Some characters are not supported by your system encoding and have been discarded.
+warning: Some characters could not be converted to your system encoding and have been discarded. See --raw.
 END_ERR
 
 $ENV{LC_ALL} = '';
@@ -291,3 +292,23 @@ ARTIST=éàç
 I=ùÎ
 END_OUT
 }
+
+
+####################################################################################################
+# Raw edition
+
+is_deeply(opustags(qw(-S out.opus -i --raw -a), "U=\xFE", {in => <<"END_IN", mode => ':raw'}), ['', '', 0], 'raw set-all with binary data');
+T=\xFF
+END_IN
+
+is_deeply(opustags(qw(out.opus)), [<<"END_OUT", <<'END_ERR', 0], 'default read with binary data');
+T=
+U=
+END_OUT
+warning: Some characters could not be converted to your system encoding and have been discarded. See --raw.
+END_ERR
+
+is_deeply(opustags(qw(out.opus --raw), { mode => ':raw' }), [<<"END_OUT", '', 0], 'raw read');
+T=\xFF
+U=\xFE
+END_OUT

--- a/t/opustags.t
+++ b/t/opustags.t
@@ -276,11 +276,10 @@ is_deeply(opustags('-i', 'out.opus', "--add=I=\xf9\xce", {mode => ':raw'}), ['',
 
 is_deeply(opustags('out.opus', {mode => ':raw'}), [<<"END_OUT", <<'END_ERR', 0], 'read tags in ISO-8859-1');
 encoder=Lavc58.18.100 libopus
-TITLE=
 ARTIST=\xe9\xe0\xe7
 I=\xf9\xce
 END_OUT
-warning: Some characters could not be converted to your system encoding and have been discarded. See --raw.
+warning: Some tags could not be displayed because of incompatible encoding. See --raw.
 END_ERR
 
 $ENV{LC_ALL} = '';
@@ -302,10 +301,8 @@ T=\xFF
 END_IN
 
 is_deeply(opustags(qw(out.opus)), [<<"END_OUT", <<'END_ERR', 0], 'default read with binary data');
-T=
-U=
 END_OUT
-warning: Some characters could not be converted to your system encoding and have been discarded. See --raw.
+warning: Some tags could not be displayed because of incompatible encoding. See --raw.
 END_ERR
 
 is_deeply(opustags(qw(out.opus --raw), { mode => ':raw' }), [<<"END_OUT", '', 0], 'raw read');

--- a/t/system.cc
+++ b/t/system.cc
@@ -46,7 +46,7 @@ void check_converter()
 	is(out, ephemere_iso, "conversion from UTF-8 is correct");
 
 	rc = from_utf8("\xFF\xFF", out);
-	is(rc, ot::st::information_lost, "conversion from bad UTF-8 is lossy");
+	is(rc, ot::st::badly_encoded, "conversion from bad UTF-8 fails");
 }
 
 void check_shell_esape()

--- a/t/system.cc
+++ b/t/system.cc
@@ -34,7 +34,7 @@ void check_converter()
 {
 	const char* ephemere_iso = "\xc9\x70\x68\xe9\x6d\xe8\x72\x65";
 	ot::encoding_converter to_utf8("ISO_8859-1", "UTF-8");
-	ot::encoding_converter from_utf8("UTF-8", "ISO_8859-1//TRANSLIT");
+	ot::encoding_converter from_utf8("UTF-8", "ISO_8859-1//IGNORE");
 	std::string out;
 
 	ot::status rc = to_utf8(ephemere_iso, out);
@@ -46,7 +46,7 @@ void check_converter()
 	is(out, ephemere_iso, "conversion from UTF-8 is correct");
 
 	rc = from_utf8("\xFF\xFF", out);
-	is(rc, ot::st::badly_encoded, "conversion from bad UTF-8 fails");
+	is(rc, ot::st::information_lost, "conversion from bad UTF-8 is lossy");
 }
 
 void check_shell_esape()


### PR DESCRIPTION
Use //IGNORE instead of less-widely supported //TRANSLIT, meaning invalid characters will be skipped. @0xJes could you please confirm musl accepts this?

Introduce --raw for disable encoding conversions when they get in the way.

Close #46.