### PR TITLE
Make use of padding space when possible

### DIFF
--- a/src/opustags.h
+++ b/src/opustags.h
@@ -491,7 +491,7 @@ std::list<std::string> read_comments(FILE* input, bool raw);
  *
  * The strings are all UTF-8.
  */
-void delete_comments(std::list<std::string>& comments, const std::string& selector);
+int delete_comments(std::list<std::string>& comments, const std::string& selector);
 
 /**
  * Main entry point to the opustags program, and pretty much the same as calling opustags from the


### PR DESCRIPTION
Normally when adding or removing tags, the data is just directly inserted or cut out.

With these changes the padding space in the metadata is used instead (overwritten when tags are added, or inserted when tags are removed), to preserve the original file size if the tag changes are small enough.

This works for my use case but I realize the usefulness of this functionality is subjective, so feel free to close this PR if you don't think they are worth including.