### PR TITLE
Use intermediate deleter for invoking fclose() on unique_ptr<FILE>

### DIFF
--- a/src/opustags.h
+++ b/src/opustags.h
@@ -119,13 +119,16 @@ using byte_string_view = std::basic_string_view<uint8_t>;
  * \{
  */
 
+/** Local helper deleter lambda */
+inline auto fclose_deleter = [](FILE* f) { fclose(f); };
+
 /**
  * Smart auto-closing FILE* handle.
  *
  * It implictly converts from an already opened FILE*.
  */
-struct file : std::unique_ptr<FILE, decltype(&fclose)> {
-	file(FILE* f = nullptr) : std::unique_ptr<FILE, decltype(&fclose)>(f, &fclose) {}
+struct file : std::unique_ptr<FILE, decltype(fclose_deleter)> {
+	file(FILE* f = nullptr) : std::unique_ptr<FILE, decltype(fclose_deleter)>(f, fclose_deleter) {}
 };
 
 /**


### PR DESCRIPTION
This fixes warnings from GCC 14 about ignored attributes when using std::unique_ptr\<FILE\>

Before:
```console
[ 12%] Building CXX object CMakeFiles/ot.dir/src/base64.cc.o
In file included from /home/eddy/dev/EXT/opustags/src/base64.cc:12:
/home/eddy/dev/EXT/opustags/src/opustags.h:127:54: warning: ignoring attributes on template argument 'int (*)(FILE*)' [-Wignored-attributes]
  127 | struct file : std::unique_ptr<FILE, decltype(&fclose)> {
      |                                                      ^
/home/eddy/dev/EXT/opustags/src/opustags.h: In constructor 'ot::file::file(FILE*)':
/home/eddy/dev/EXT/opustags/src/opustags.h:128:74: warning: ignoring attributes on template argument 'int (*)(FILE*)' [-Wignored-attributes]
  128 |         file(FILE* f = nullptr) : std::unique_ptr<FILE, decltype(&fclose)>(f, &fclose) {}
      |                                                                          ^
[ 25%] Building CXX object CMakeFiles/ot.dir/src/cli.cc.o
In file included from /home/eddy/dev/EXT/opustags/src/cli.cc:9:
...
```

Verified no leaks using Valgrind after the change, for good measure:

```console
$ valgrind --track-fds=yes ./opustags -i 1.opus -a DUMMY=test
==63502== Memcheck, a memory error detector
==63502== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==63502== Using Valgrind-3.23.0 and LibVEX; rerun with -h for copyright info
==63502== Command: ./opustags -i 1.opus -a DUMMY=test
==63502== 
==63502== FILE DESCRIPTORS: 3 open (3 std) at exit.
==63502== 
==63502== HEAP SUMMARY:
==63502==     in use at exit: 0 bytes in 0 blocks
==63502==   total heap usage: 72 allocs, 72 frees, 411,180 bytes allocated
==63502== 
==63502== All heap blocks were freed -- no leaks are possible
==63502== 
==63502== For lists of detected and suppressed errors, rerun with: -s
==63502== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```