### PR TITLE
Fix string out-of-bounds access

### DIFF
--- a/src/base64.cc
+++ b/src/base64.cc
@@ -56,7 +56,7 @@ std::u8string ot::encode_base64(ot::byte_string_view src)
 ot::byte_string ot::decode_base64(std::u8string_view src)
 {
 	// Remove the padding and rely on the string length instead.
-	while (src.back() == u8'=')
+	while (!src.empty() && src.back() == u8'=')
 		src.remove_suffix(1);
 
 	size_t olen = src.size() / 4 * 3; // Whole blocks;


### PR DESCRIPTION
Running the tests with the program compiled with custom flags discovered an out of bounds access:
```
<mock-chroot> sh-5.2# ./base64.t 
1..2
ok - base64 encoding
/usr/include/c++/14/string_view:283: constexpr const std::basic_string_view<_CharT, _Traits>::value_type& std::basic_string_view<_CharT, _Traits>::back() const [with _CharT = char8_t; _Traits = std::char_traits<char8_t>; const_reference = const char8_t&]: Assertion 'this->_M_len > 0' failed.
Aborted (core dumped)
```