### PR TITLE
Add Windows endian conversions

### DIFF
--- a/src/opustags.h
+++ b/src/opustags.h
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <time.h>
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>
@@ -54,6 +55,25 @@
 #define htobe32(x) OSSwapHostToBigInt32(x)
 #define be32toh(x) OSSwapBigToHostInt32(x)
 #endif
+
+#ifdef _WIN32
+// Windows has no <endian.h>. It's always little-endian in practice, so the
+// LE conversions are no-ops; for BE, use the compiler's byte-swap builtin
+// rather than hand-rolled masking/shifting. Both MinGW-w64 (GCC/Clang) and
+// MSVC provide one.
+
+#  if defined(__GNUC__) || defined(__clang__)
+inline uint32_t htobe32(uint32_t x) { return __builtin_bswap32(x); }
+inline uint32_t be32toh(uint32_t x) { return __builtin_bswap32(x); }
+#  else
+#    include <cstdlib>
+inline uint32_t htobe32(uint32_t x) { return _byteswap_ulong(x); }
+inline uint32_t be32toh(uint32_t x) { return _byteswap_ulong(x); }
+#  endif
+inline uint32_t htole32(uint32_t x) { return x; }
+inline uint32_t le32toh(uint32_t x) { return x; }
+#endif
+
 
 using namespace std::literals;
 


### PR DESCRIPTION
Adds the Windows-specific endian conversion support needed for the Windows port.

Provides htobe32() / be32toh() using compiler byte-swap intrinsics.
Provides htole32() / le32toh() for Windows.
Keeps the existing platform-specific implementations unchanged on Linux/macOS.

This is the first part of the Windows port and is intended to be followed by separate PRs for file handling and other Windows compatibility work.