### PR TITLE
Add Windows file manipulation support

### DIFF
--- a/src/cli.cc
+++ b/src/cli.cc
@@ -20,7 +20,6 @@
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
-#include "win32_compat.h"
 #endif
 
 static const char help_message[] =
@@ -448,7 +447,7 @@ static void edit_tags_interactively(ot::opus_tags& tags, const std::optional<std
 	}
 
 	// Applying the new tags.
-	tags_file = fopen(tags_path.c_str(), OT_FOPEN_RE);
+	tags_file = fopen(tags_path.c_str(), "rb" OT_FOPEN_CLOEXEC);
 	if (tags_file == nullptr)
 		throw ot::status {ot::st::standard_error, "Error opening " + tags_path + ": " + strerror(errno)};
 	try {
@@ -485,7 +484,7 @@ static void output_cover(const ot::opus_tags& tags, const ot::options &opt)
 			throw ot::status {ot::st::error, "Could not identify '" + opt.cover_out.value() + "': " + strerror(errno)};
 		}
 
-		output = fopen(opt.cover_out->c_str(), OT_FOPEN_W);
+		output = fopen(opt.cover_out->c_str(), "wb" OT_FOPEN_CLOEXEC);
 		if (output == nullptr)
 			throw ot::status {ot::st::standard_error, "Could not open '" + opt.cover_out.value() + "' for writing: " + strerror(errno)};
 	}
@@ -563,7 +562,7 @@ static void run_single(const ot::options& opt, const std::string& path_in, const
 	ot::file input;
 	if (path_in == "-")
 		input = stdin;
-	else if ((input = fopen(path_in.c_str(), OT_FOPEN_RE)) == nullptr)
+	else if ((input = fopen(path_in.c_str(), "rb" OT_FOPEN_CLOEXEC)) == nullptr)
 		throw ot::status {ot::st::standard_error,
 		                  "Could not open '" + path_in + "' for reading: " + strerror(errno)};
 	ot::ogg_reader reader(input.get());
@@ -604,7 +603,7 @@ static void run_single(const ot::options& opt, const std::string& path_in, const
 		/* The output file exists. */
 		if (!S_ISREG(output_info.st_mode)) {
 			/* Special files are opened for writing directly. */
-			if ((final_output = fopen(path_out->c_str(), OT_FOPEN_WE)) == nullptr)
+			if ((final_output = fopen(path_out->c_str(), "wb" OT_FOPEN_CLOEXEC)) == nullptr)
 				throw ot::status {ot::st::standard_error,
 				                  "Could not open '" + path_out.value() + "' for writing: " + strerror(errno)};
 			output = final_output.get();

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -20,6 +20,7 @@
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
+#include "win32_compat.h"
 #endif
 
 static const char help_message[] =

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -17,6 +17,12 @@
 #include <unistd.h>
 #include <algorithm>
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#include "win32_compat.h"
+#endif
+
 static const char help_message[] =
 PROJECT_NAME " version " PROJECT_VERSION
 R"raw(
@@ -442,7 +448,7 @@ static void edit_tags_interactively(ot::opus_tags& tags, const std::optional<std
 	}
 
 	// Applying the new tags.
-	tags_file = fopen(tags_path.c_str(), "re");
+	tags_file = fopen(tags_path.c_str(), OT_FOPEN_RE);
 	if (tags_file == nullptr)
 		throw ot::status {ot::st::standard_error, "Error opening " + tags_path + ": " + strerror(errno)};
 	try {
@@ -479,7 +485,7 @@ static void output_cover(const ot::opus_tags& tags, const ot::options &opt)
 			throw ot::status {ot::st::error, "Could not identify '" + opt.cover_out.value() + "': " + strerror(errno)};
 		}
 
-		output = fopen(opt.cover_out->c_str(), "w");
+		output = fopen(opt.cover_out->c_str(), OT_FOPEN_W);
 		if (output == nullptr)
 			throw ot::status {ot::st::standard_error, "Could not open '" + opt.cover_out.value() + "' for writing: " + strerror(errno)};
 	}
@@ -557,7 +563,7 @@ static void run_single(const ot::options& opt, const std::string& path_in, const
 	ot::file input;
 	if (path_in == "-")
 		input = stdin;
-	else if ((input = fopen(path_in.c_str(), "re")) == nullptr)
+	else if ((input = fopen(path_in.c_str(), OT_FOPEN_RE)) == nullptr)
 		throw ot::status {ot::st::standard_error,
 		                  "Could not open '" + path_in + "' for reading: " + strerror(errno)};
 	ot::ogg_reader reader(input.get());
@@ -598,7 +604,7 @@ static void run_single(const ot::options& opt, const std::string& path_in, const
 		/* The output file exists. */
 		if (!S_ISREG(output_info.st_mode)) {
 			/* Special files are opened for writing directly. */
-			if ((final_output = fopen(path_out->c_str(), "we")) == nullptr)
+			if ((final_output = fopen(path_out->c_str(), OT_FOPEN_WE)) == nullptr)
 				throw ot::status {ot::st::standard_error,
 				                  "Could not open '" + path_out.value() + "' for writing: " + strerror(errno)};
 			output = final_output.get();

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -75,19 +75,9 @@ inline uint32_t le32toh(uint32_t x) { return x; }
 #endif
 
 #ifdef _WIN32
-// MSVCRT/UCRT's fopen does not understand the glibc "e" mode character
-// (O_CLOEXEC). We gate it per platform instead of dropping it outright, so
-// POSIX builds keep close-on-exec, and Windows builds get explicit binary
-// mode, which it needs since text mode does CRLF translation that would
-// corrupt tag data and Ogg streams.
-
-# define OT_FOPEN_RE "rb"
-# define OT_FOPEN_WE "wb"
-# define OT_FOPEN_W "wb"
+# define OT_FOPEN_CLOEXEC ""
 #else
-# define OT_FOPEN_RE "re"
-# define OT_FOPEN_WE "we"
-# define OT_FOPEN_W "w"
+# define OT_FOPEN_CLOEXEC "e"
 #endif
 
 using namespace std::literals;

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -31,6 +31,7 @@
 #include <stdio.h>
 #include <time.h>
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <memory>
@@ -54,6 +55,25 @@
 #define htobe32(x) OSSwapHostToBigInt32(x)
 #define be32toh(x) OSSwapBigToHostInt32(x)
 #endif
+
+#ifdef _WIN32
+// Windows has no <endian.h>. It's always little-endian in practice, so the
+// LE conversions are no-ops; for BE, use the compiler's byte-swap builtin
+// rather than hand-rolled masking/shifting. Both MinGW-w64 (GCC/Clang) and
+// MSVC provide one.
+
+#  if defined(__GNUC__) || defined(__clang__)
+inline uint32_t htobe32(uint32_t x) { return __builtin_bswap32(x); }
+inline uint32_t be32toh(uint32_t x) { return __builtin_bswap32(x); }
+#  else
+#    include <cstdlib>
+inline uint32_t htobe32(uint32_t x) { return _byteswap_ulong(x); }
+inline uint32_t be32toh(uint32_t x) { return _byteswap_ulong(x); }
+#  endif
+inline uint32_t htole32(uint32_t x) { return x; }
+inline uint32_t le32toh(uint32_t x) { return x; }
+#endif
+
 
 using namespace std::literals;
 

--- a/src/opustags.h
+++ b/src/opustags.h
@@ -74,6 +74,21 @@ inline uint32_t htole32(uint32_t x) { return x; }
 inline uint32_t le32toh(uint32_t x) { return x; }
 #endif
 
+#ifdef _WIN32
+// MSVCRT/UCRT's fopen does not understand the glibc "e" mode character
+// (O_CLOEXEC). We gate it per platform instead of dropping it outright, so
+// POSIX builds keep close-on-exec, and Windows builds get explicit binary
+// mode, which it needs since text mode does CRLF translation that would
+// corrupt tag data and Ogg streams.
+
+# define OT_FOPEN_RE "rb"
+# define OT_FOPEN_WE "wb"
+# define OT_FOPEN_W "wb"
+#else
+# define OT_FOPEN_RE "re"
+# define OT_FOPEN_WE "we"
+# define OT_FOPEN_W "w"
+#endif
 
 using namespace std::literals;
 

--- a/src/system.cc
+++ b/src/system.cc
@@ -40,6 +40,7 @@ void ot::partial_file::open(const char* destination)
 		              strerror(errno)};
 }
 
+#ifndef _WIN32
 static mode_t get_umask()
 {
 	// libc doesn’t seem to provide a way to get umask without changing it, so we need this workaround.
@@ -72,13 +73,27 @@ static void copy_permissions(const char* source, const char* dest)
 	if (chmod(dest, target_mode) == -1)
 		fprintf(stderr, "warning: Could not set mode of %s: %s\n", dest, strerror(errno));
 }
+#endif
 
 void ot::partial_file::commit()
 {
 	if (file == nullptr)
 		return;
 	file.reset();
+#ifndef _WIN32
+	// Windows does not use Unix-style file modes; the temporary file already has the correct
+	// default permissions. On Unix, we copy the original file's permissions.
 	copy_permissions(final_name.c_str(), temporary_name.c_str());
+#endif
+
+#ifdef _WIN32
+	// Windows rename() refuses to overwrite an existing file
+	if (remove(final_name.c_str()) != 0 && errno != ENOENT) {
+		throw status {st::standard_error,
+		              "Could not remove original file '" + final_name + "': " +
+		              strerror(errno) + "."};
+	}
+#endif
 	if (rename(temporary_name.c_str(), final_name.c_str()) == -1)
 		throw status {st::standard_error,
 		              "Could not move the result file '" + temporary_name + "' to '" +

--- a/src/system.cc
+++ b/src/system.cc
@@ -81,23 +81,52 @@ void ot::partial_file::commit()
 		return;
 	file.reset();
 #ifndef _WIN32
-	// Windows does not use Unix-style file modes; the temporary file already has the correct
-	// default permissions. On Unix, we copy the original file's permissions.
+   // Windows does not use Unix-style file modes; the temporary file already has the correct
+   // default permissions. On Unix, we copy the original file's permissions.
 	copy_permissions(final_name.c_str(), temporary_name.c_str());
 #endif
 
 #ifdef _WIN32
-	// Windows rename() refuses to overwrite an existing file
-	if (remove(final_name.c_str()) != 0 && errno != ENOENT) {
-		throw status {st::standard_error,
-		              "Could not remove original file '" + final_name + "': " +
-		              strerror(errno) + "."};
+	// Windows rename() refuses to overwrite an existing file.
+	std::string backup_name = final_name + ".bak";
+	remove(backup_name.c_str());   // ignore errors (leftover from a previous crash)
+
+	bool had_original = false;
+	if (rename(final_name.c_str(), backup_name.c_str()) == 0) {
+		had_original = true;
+	} else if (errno != ENOENT) {
+		// ENOENT means there was no original file to back up (e.g. this
+		// is a new file), which is fine. Anything else is a real problem.
+		throw status{st::standard_error,
+		             "Could not back up original file '" + final_name + "': " +
+		             strerror(errno) + "."};
 	}
-#endif
+
+	if (rename(temporary_name.c_str(), final_name.c_str()) != 0) {
+		// Failed to install the new file – try to restore the original.
+		if (had_original) {
+			if (rename(backup_name.c_str(), final_name.c_str()) != 0) {
+				throw status{st::standard_error,
+				             "Could not install new file and could not restore original. "
+				             "Original is in '" + backup_name + "', "
+				             "new data is in '" + temporary_name + "': " +
+				             strerror(errno)};
+			}
+		}
+		throw status{st::standard_error,
+		             "Could not move the result file '" + temporary_name + "' to '" +
+		             final_name + "': " + strerror(errno) + "."};
+	}
+
+	// Success – only now is it safe to delete the backup.
+	if (had_original)
+		remove(backup_name.c_str());
+#else
 	if (rename(temporary_name.c_str(), final_name.c_str()) == -1)
-		throw status {st::standard_error,
-		              "Could not move the result file '" + temporary_name + "' to '" +
-		              final_name + "': " + strerror(errno) + "."};
+		throw status{st::standard_error,
+		             "Could not move the result file '" + temporary_name + "' to '" +
+		             final_name + "': " + strerror(errno) + "."};
+#endif
 }
 
 void ot::partial_file::abort()

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifdef _WIN32
+
+#include <io.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <cstring>
+
+#define strncasecmp _strnicmp
+
+// getdelim() and mkstemps() are POSIX/BSD extensions MSVCRT/UCRT does not
+// provide. HAVE_GETDELIM / HAVE_MKSTEMPS are defined by CMake via
+// check_function_exists() when the target runtime already has them, so
+// these declarations (and their implementations in system.cc) only apply
+// when actually needed. This is scoped to Windows only, so it has no
+// effect on the Linux/Mac build.
+#ifndef HAVE_GETDELIM
+ssize_t getdelim(char** lineptr, size_t* n, int delim, FILE* stream);
+#endif
+
+#ifndef HAVE_MKSTEMPS
+int mkstemps(char* tmpl, int suffixlen);
+#endif
+
+#endif


### PR DESCRIPTION
Adds the Windows-specific file handling needed for the port.

Uses Windows-compatible binary fopen() modes.
Avoids Unix-only permission handling on Windows.
Handles replacing an existing destination file before rename(), since Windows rename() does not overwrite existing files.

This PR is intended to follow the Windows endian conversion changes in the previous PR.